### PR TITLE
docs(model-eval-prep): Updated README to better provide UI guidance

### DIFF
--- a/genai-quickstart-pocs-python/amazon-bedrock-model-eval-poc/README.md
+++ b/genai-quickstart-pocs-python/amazon-bedrock-model-eval-poc/README.md
@@ -62,3 +62,39 @@ Your machine should now be configured to run the POC. To start the POC, execute 
 streamlit run app.py
 ```
 This should start the POC and open a browser window to the application. Follow the instructions in the application to generate prompt data.
+
+# Using the Model Evaluator Data Prep tool
+Once the streamlit app is up and running in your browser, it's time to complete the form in the tool with the correct details from your data. 
+
+There are four evaluation types: **Question & Answer (Q&A)**, **Text Generation**, **Text Summarization**, and **Classification**. Depending on your data and goals, you may be able to execute different evaluations on the same data using the tool to prep the data for each evaluation type. 
+
+*Currently, CSV data requires column headers. **Please make sure your data includes headers in your CSV file before starting with the tool.***
+
+Once you complete the fields in the tool, it will generate `.jsonl` files for use with Amazon Bedrock Model Evaluator. Download the `.jsonl` files and follow the [guidance]((https://docs.aws.amazon.com/bedrock/latest/userguide/model-evaluation.html)) from Amazon Bedrock Model Evaluator to start evaluating models with your custom prompts. 
+
+## Question & Answer (Q&A)
+The Question & Answer (Q&A) model evaluation prep builds a prompt that includes the question and possible answer choices. For the Q&A workflow, you will be asked to map the following CSV columns. You will need to map the following columns:
+* Question ID - The unique ID for each question. 
+* Question - The quetion text
+* Answer - The answer value to the question
+* Is Correct - If the answer in is correct or incorrect
+* Category - The question category (Optional)
+
+At this time, data mapping for Q&A requires each answer to have a row. Answers are grouped by Question by using the question ID. 
+
+## Text Summarization
+The text summarization model evaluation prep builds a prompt that includes the CSV columns you select and is instructed to summarize the provided content. 
+
+Additionally, you will need to map the Expected Answer, which is what you expect the Bedrock Model to respond with as a summary. This is used to evaluate the quality of output compared to your expectations. Category can also be mapped, but is not required. 
+
+## Classification
+The classification model evaluation prep builds a prompt that includes the CSV columns you select and is instructed to respond with a classification category from a list of provided categories. 
+
+Additionally, you will need to map the Expected Answer, which is what you expect the Bedrock Model to respond with as a classification category. 
+You will be prompted to provide a comma seperated list of classification categories that you'd like to the model to use when determining what classification category should assigned as the response. Category can also be mapped, but is not required, and doesn't impact the classification category determination.
+
+
+## Text Generation
+The text generation model evalution prep builds a prompt that includes the CSV columns you select and is instructed to generate text using the provided text.
+
+Additionally, you will need to map the Expected Answer, which is what you expect the Bedrock Model to respond with as Generated Text. Category can also be mapped, but is not required. 


### PR DESCRIPTION
This PR adds additional documentation to the Amazon-Bedrock-Model-Eval-POC to better guide users on how the UI functions. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
