### PR TITLE
Simplification suggestion for Text to SQL pattern

### DIFF
--- a/genai-quickstart-pocs-python/amazon-bedrock-amazon-athena-poc/SampleData/moma_examples.yaml
+++ b/genai-quickstart-pocs-python/amazon-bedrock-amazon-athena-poc/SampleData/moma_examples.yaml
@@ -1,7 +1,7 @@
-- answer: There are 15086 rows in the artists table.
+- answer: There are 15089 rows in the artists table.
   input: How many rows are in the artists table?
   sql_cmd: SELECT count(*) FROM artists;
-  sql_result: '[(15086,)]'
+  sql_result: '[(15089,)]'
   table_info: |
     CREATE TABLE artists
     (
@@ -24,8 +24,8 @@
 
 - answer: There are 2 artist names starts with 'A'.
   input: How many artist names starts with 'A'?
-  sql_cmd: SELECT * FROM artists WHERE full_name LIKE 'a%';
-  sql_result: '[(2,)]'
+  sql_cmd: SELECT COUNT(artist_id) as count_artists FROM artists WHERE LOWER(full_name) LIKE 'a%';
+  sql_result: '[(1126,)]'
   table_info: |
     CREATE TABLE artists
     (
@@ -49,7 +49,7 @@
 - answer: There are 839 artists whose nationality is French.
   input: How many artists are there where nationality is French?
   sql_cmd: SELECT count(*) FROM artists WHERE nationality = 'French';
-  sql_result: '[(839,)]'
+  sql_result: '[(833,)]'
   table_info: |
     table_info: |
     CREATE TABLE artists
@@ -146,14 +146,14 @@
     103321	"Untitled (page from Sump)"	25520	1994	"Page with chromogenic color print and text"	"12 x 9 1/2' (30.5 x 24.1 cm)"	"2006-05-11"	"E.T. Harmax Foundation Fund"	"N"	"Photography"	"Photograph"	"415.2006.12"			"30.4801"		"24.13"
     10	"The Manhattan Transcripts Project, New York, New York, Episode 1: The Park"	7056		"Gelatin silver photograph"	"14 x 18' (35.6 x 45.7 cm)"	"1995-01-17"	"Purchase and partial gift of the architect in honor of Lily Auchincloss"	"Y"	"Architecture & Design"	"Architecture"	"3.1995.11"			"35.6"		"45.7"
     */
-- answer: There are 1278 artworks by Pablo Picasso.
+- answer: There are 894 artworks by Pablo Picasso.
   input: How many artworks are by the artist 'Pablo Picasso'?
   sql_cmd: |
     SELECT count(*)
     FROM artworks
     JOIN artists ON artists.artist_id = artworks.artist_id
     WHERE artists.full_name = 'Pablo Picasso';
-  sql_result: '[(1278,)]'
+  sql_result: '[(894,)]'
   table_info: |
     table_info: |
     CREATE TABLE artists
@@ -281,10 +281,10 @@
     103321	"Untitled (page from Sump)"	25520	1994	"Page with chromogenic color print and text"	"12 x 9 1/2' (30.5 x 24.1 cm)"	"2006-05-11"	"E.T. Harmax Foundation Fund"	"N"	"Photography"	"Photograph"	"415.2006.12"			"30.4801"		"24.13"
     10	"The Manhattan Transcripts Project, New York, New York, Episode 1: The Park"	7056		"Gelatin silver photograph"	"14 x 18' (35.6 x 45.7 cm)"	"1995-01-17"	"Purchase and partial gift of the architect in honor of Lily Auchincloss"	"Y"	"Architecture & Design"	"Architecture"	"3.1995.11"			"35.6"		"45.7"
     */
-- answer: There are 1588 artworks classified as sculptures.
+- answer: There are 908 artworks classified as sculptures.
   input: How many artworks are classified as sculptures?
   sql_cmd: SELECT count(*) FROM artworks WHERE classification = 'Sculpture';
-  sql_result: '[(1588, )]'
+  sql_result: '[(908, )]'
   table_info: |
     table_info: |
     CREATE TABLE artists
@@ -340,13 +340,13 @@
     */
 - answer: |
     The five most common artwork classifications are:
-    1. Photograph - 26541
-    2. Print - 25426
-    3. Illustrated_Book - 23716
-    4. Not_Assigned - 11034
-    5. Drawing - 10549
+    1. Photograph: 16,177 items
+    2. Print: 15,224 items
+    3. Prints & Illustrated Books: 14,388 items
+    4. Illustrated Book: 9,783 items
+    5. Drawing: 7,076 items
 
-  input: What the five most common artwork classifications?
+  input: What are the five most common artwork classifications?
   sql_cmd: |
     SELECT classification, COUNT(classification)
     FROM artworks

--- a/genai-quickstart-pocs-python/amazon-bedrock-amazon-athena-poc/amazon_athena_bedrock_query.py
+++ b/genai-quickstart-pocs-python/amazon-bedrock-amazon-athena-poc/amazon_athena_bedrock_query.py
@@ -1,129 +1,259 @@
 import os
 from dotenv import load_dotenv
 import yaml
-from langchain.prompts.few_shot import FewShotPromptTemplate
-from langchain.prompts.prompt import PromptTemplate
-from langchain.sql_database import SQLDatabase
-from langchain.chains.sql_database.prompt import PROMPT_SUFFIX, _postgres_prompt
-from langchain.embeddings.huggingface import HuggingFaceEmbeddings
-from langchain.llms import Bedrock
-from langchain.prompts.example_selector.semantic_similarity import (
-    SemanticSimilarityExampleSelector,
-)
-from langchain_community.vectorstores import Chroma
-from langchain_experimental.sql import SQLDatabaseChain
+import boto3
+import json
+import time
+
 
 # Loading environment variables
 load_dotenv()
-# configuring your instance of Amazon bedrock, selecting the CLI profile, modelID, endpoint url and region.
-llm = Bedrock(
-    credentials_profile_name=os.getenv("profile_name"),
-    model_id="amazon.titan-text-express-v1",
-    endpoint_url="https://bedrock-runtime.us-east-1.amazonaws.com",
-    region_name="us-east-1",
-    verbose=True
-)
 
+# Configure AWS Bedrock client
+bedrock_client = boto3.client(
+    service_name="bedrock-runtime",
+    region_name=os.getenv('region_name'),
+    aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+    aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY")
+)
 
 # Executing the SQL database chain with the users question
 def athena_answer(question):
     """
-    This function collects all necessary information to execute the sql_db_chain and get an answer generated, taking
+    This function collects all necessary information to generate the SQL Query 
+    a natural language question in and returning a generated SQL query.
+    :param question: The question the user passes in from the frontend
+    :return: The generated SQL query for Athena
+    """
+    
+    prompt_data = """
+        <Instructions>
+            You are an expert SQL query generator for AWS Athena. Your task is to generate precise SQL queries from natural language questions using the provided database schema.
+            Key Requirements:
+                1. Generate syntactically correct AWS Athena SQL queries to answer the question in <question> tag
+                2. Use only columns that exist in the schema
+                3. Select specific and relevant columns instead of using SELECT *
+                4. use only the column names that you can see in the schema description. 
+                5. Properly qualify column names with table names when needed
+                6. Ensure table joins are properly constructed when needed
+                7. Return only the SQL query without any explanations or additional comments
+                8. Use appropriate aggregation functions (COUNT, SUM, AVG, etc.) when needed
+                9. Handle string comparisons case-insensitively using LOWER() function
+            
+            Schema Guidelines:
+                - Reference only tables and columns defined in the <database_schema> tags
+                - Pay attention to data types and constraints
+                - Use appropriate SQL functions based on column types
+                - Consider NULL handling where appropriate
+                - Use JOIN operations when combining data from different tables 
+
+            Output Format:
+                - Return only the SQL query
+                - Use proper SQL formatting with clear indentation
+                - Include table aliases for better readability
+                - End queries with semicolon           
+            
+        </Instructions>
+
+        <database_schema>
+            CREATE TABLE artists
+                (
+                    artist_id integer NOT NULL,
+                    full_name character varying(200),
+                    nationality character varying(50),
+                    gender character varying(25),
+                    birth_year integer,
+                    death_year integer,
+                    CONSTRAINT artists_pk PRIMARY KEY (artist_id)
+                )        
+        
+            CREATE TABLE artworks
+                (
+                    artwork_id integer NOT NULL,
+                    title character varying(500),
+                    artist_id integer NOT NULL,
+                    date integer,
+                    medium character varying(250),
+                    dimensions text,
+                    acquisition_date text,
+                    credit text,
+                    catalogue character varying(250),
+                    department character varying(250),
+                    classification character varying(250),
+                    object_number text,
+                    diameter_cm text,
+                    circumference_cm text,
+                    height_cm text,
+                    length_cm text,
+                    width_cm text,
+                    depth_cm text,
+                    weight_kg text,
+                    durations integer,
+                    CONSTRAINT artworks_pk PRIMARY KEY (artwork_id)
+                )
+        </database_schema>
+        <examples>
+            Example 1:
+            Q: "How many artists are there where nationality is French?"
+            A: "SELECT COUNT(artist_id) as french_artists_count FROM artists WHERE nationality = 'French';"
+
+            Example 2:
+            Q: "How many artist names start with 'A'?"
+            A: "SELECT COUNT(artist_id) as count_artists FROM artists WHERE LOWER(full_name) LIKE 'a%';"
+
+            Example 3:
+            Q: "List all artworks and their artists from the 19th century"
+            A:
+            SELECT a.full_name as artist_name, aw.title as artwork_title, aw.date as creation_date
+            FROM artworks aw
+            JOIN artists a ON a.artist_id = aw.artist_id
+            WHERE aw.date BETWEEN 1800 AND 1899
+            ORDER BY aw.date;
+        </examples>
+
+        <question>
+            {input_question}
+        </question>
+        """
+    
+    # formatting the prompt template to add context and user query
+    formatted_prompt_data = prompt_data.format(input_question=question)
+
+    # Configuring the model parameters, preparing for inference
+    # TODO: TUNE THESE PARAMETERS TO OPTIMIZE FOR YOUR USE CASE
+    prompt = {
+        "anthropic_version": "bedrock-2023-05-31",
+        "max_tokens": 4096,
+        "temperature": 0.5,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": formatted_prompt_data
+                    }
+                ]
+            }
+        ]
+    }
+    # formatting the prompt as a json string
+    json_prompt = json.dumps(prompt)    
+
+    # invoking Claude 3.5, passing in our prompt
+    response = bedrock_client.invoke_model(body=json_prompt, modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+                                    accept="application/json", contentType="application/json")
+    # getting the response from Claude3 and parsing it to return to the end user
+    response_body = json.loads(response.get('body').read())
+    # the final string returned to the end user
+    answer = response_body['content'][0]['text']
+
+    return answer
+
+def get_athena_answer(question, query):
+
+    """
+    This function collects all necessary information to generate the SQL Query and get an answer generated, taking
     a natural language question in and returning an answer and generated SQL query.
     :param question: The question the user passes in from the frontend
+    :param query: The generated SQL query from the athena_answer function
     :return: The final answer in natural langauge along with the generated SQL query.
     """
-    # retrieving the final Amazon Athena URI to initiate a connection with the database
-    athena_uri = get_athena_uri()
-    # formatting the Amazon Athena URI and preparing it to be used with Langchain sql_db_chain
-    db = SQLDatabase.from_uri(athena_uri)
-    # loading the sample prompts from SampleData/moma_examples.yaml
-    examples = load_samples()
-    # initiating the sql_db_chain with the specific LLM we are using, the db connection string and the selected examples
-    sql_db_chain = load_few_shot_chain(llm, db, examples)
-    # the answer created by Amazon Bedrock and ultimately passed back to the end user
-    answer = sql_db_chain(question)
-    # Passing back both the generated SQL query and the final result in a natural language format
-    return answer["intermediate_steps"][1], answer["result"]
 
+    athena_query_answer = execute_athena_query(query)
+    
+    prompt_data = """
+        <Instructions>
+            Based on the original <question>, your task is to convert SQL query results in <answer> into clear, concise human-readable answers.
+            Requirements:
+                1. Transform the data from <answer> into natural language that directly addresses the <question>
+                2. Present numerical results with appropriate formatting and units
+                3. Structure multiple items using:
+                    - Bullet points for lists
+                    - Tables for complex data
+                    - Clear hierarchical organization when needed
+                4. Keep the answer focused only on information present in the results.
+                5. Maintain factual accuracy without interpretation or speculation
+                6. Use clear, professional language 
+            <question>
+                {input_question}
+            </question>
+            <answer>
+                {athena}
+            </answer>
+            return the final answer in natural language and only this, no additional comments
+        </Instructions>
+        """
+    
+    # formatting the prompt template to add context and user query
+    formatted_prompt_data = prompt_data.format(input_question=question, athena=athena_query_answer)
 
-def get_athena_uri():
-    # SQLAlchemy 2.0 reference: https://github.com/laughingman7743/PyAthena/
-    # URI format: awsathena+rest://{aws_access_key_id}:{aws_secret_access_key}@athena.{region_name}.amazonaws.com:443/{database_name}?s3_staging_dir={s3_staging_dir}
-    """
-    This function is used to build the Amazon Athena URL and eventually used to connect to the database.
-    :return: The full Amazon Athena URL that is used to query against.
-    """
-    # setting the key parameters to build the rds connection string, these are stored in the .env file
-    aws_access_key_id = os.getenv('aws_access_key_id')
-    aws_secret_access_key = os.getenv('aws_secret_access_key')
-    region_name = os.getenv('region_name')
-    database_name = os.getenv('database_name')
-    s3_staging_dir = os.getenv('s3_staging_dir')
-    # taking all the inputted parameters and formatting them in a finalized string
-    athena_uri = f"awsathena+rest://{aws_access_key_id}:{aws_secret_access_key}@athena.{region_name}.amazonaws.com:443/{database_name}?s3_staging_dir={s3_staging_dir}"
-    # returning the final Amazon Athena URL that was built in the line of code above
-    return athena_uri
+    prompt = {
+        "anthropic_version": "bedrock-2023-05-31",
+        "max_tokens": 4096,
+        "temperature": 0.5,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": formatted_prompt_data
+                    }
+                ]
+            }
+        ]
+    }
+    # formatting the prompt as a json string
+    json_prompt = json.dumps(prompt)    
 
+    # invoking Claude3, passing in our prompt
+    response = bedrock_client.invoke_model(body=json_prompt, modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+                                    accept="application/json", contentType="application/json")
+    # getting the response from Claude3.5 and parsing it to return to the end user
+    response_body = json.loads(response.get('body').read())
+    
+    # the final string returned to the end user
+    answer = response_body['content'][0]['text']
 
-def load_samples():
-    """
-    Load the sql examples for few-shot prompting examples
-    :return: The sql samples in from the moma_examples.yaml file
-    """
-    # instantiating the sql samples variable
-    sql_samples = None
-    # opening our prompt sample file
-    with open("Sampledata/moma_examples.yaml", "r") as stream:
-        # reading our prompt samples into the sql_samples variable
-        sql_samples = yaml.safe_load(stream)
-    # returning the sql samples as a string
-    return sql_samples
+    return answer
 
-
-def load_few_shot_chain(llm, db, examples):
+def execute_athena_query(query):
     """
-    This function is used to load in the most similar prompts, format them along with the users question and then is
-    passed in to Amazon Bedrock to generate an answer.
-    :param llm: Large Language model you are using
-    :param db: The Amazon Athena database URL
-    :param examples: The samples loaded from your examples file.
-    :return: The results from the SQLDatabaseChain
-    """
-    # This is formatting the prompts that are retrieved from the SampleData/moma_examples.yaml
-    example_prompt = PromptTemplate(
-        input_variables=["table_info", "input", "sql_cmd", "sql_result", "answer"],
-        template=(
-            "{table_info}\n\nQuestion: {input}\nSQLQuery: {sql_cmd}\nSQLResult:"
-            " {sql_result}\nAnswer: {answer}"
-        ),
+    This function is used to run the Amazon Athena query 
+    :return: Answer from athena query
+    """         
+    client = boto3.client('athena', region_name=os.getenv('region_name'))
+    database = os.getenv('database_name')
+    s3_output = os.getenv('s3_staging_dir')
+    # Start the query execution
+    response = client.start_query_execution(
+        QueryString=query,
+        QueryExecutionContext={
+            'Database': database
+        },
+        ResultConfiguration={
+            'OutputLocation': s3_output,
+        }
     )
-    # instantiating the hugging face embeddings model to be used to produce embeddings of user queries and prompts
-    local_embeddings = HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
-    # The example selector loads the examples, creates the embeddings, stores them in Chroma (vector store) and a
-    # semantic search is performed to see the similarity between the question and prompts, it returns the 3 most similar
-    # prompts as defined by k
-    example_selector = SemanticSimilarityExampleSelector.from_examples(
-        examples,
-        local_embeddings,
-        Chroma,
-        k=min(3, len(examples)),
-    )
-    # This is orchestrating the example selector (finding similar prompts to the question), example_prompt (formatting
-    # the retrieved prompts, and formatting the chat history and the user input
-    few_shot_prompt = FewShotPromptTemplate(
-        example_selector=example_selector,
-        example_prompt=example_prompt,
-        prefix=_postgres_prompt + "Provide no preamble",
-        suffix=PROMPT_SUFFIX,
-        input_variables=["table_info", "input", "top_k"],
-    )
-    # Where the LLM, DB and prompts are all orchestrated to answer a user query.
-    return SQLDatabaseChain.from_llm(
-        llm,
-        db,
-        prompt=few_shot_prompt,
-        use_query_checker=True,
-        verbose=True,
-        return_intermediate_steps=True,
-    )
+
+    # Get the query execution ID
+    query_execution_id = response['QueryExecutionId']
+
+    # Wait for the query to complete
+    while True:
+        response = client.get_query_execution(QueryExecutionId=query_execution_id)
+        state = response['QueryExecution']['Status']['State']
+        
+        if state in ['SUCCEEDED', 'FAILED', 'CANCELLED']:
+            break
+        
+        time.sleep(1)  # Wait for 1 second before checking again
+
+    # If the query succeeded, fetch and return the results
+    if state == 'SUCCEEDED':
+        response = client.get_query_results(QueryExecutionId=query_execution_id)
+        results = response['ResultSet']['Rows']
+        return results
+    else:
+        raise Exception(f"Query failed with state: {state}")

--- a/genai-quickstart-pocs-python/amazon-bedrock-amazon-athena-poc/amazon_athena_bedrock_query.py
+++ b/genai-quickstart-pocs-python/amazon-bedrock-amazon-athena-poc/amazon_athena_bedrock_query.py
@@ -1,6 +1,5 @@
 import os
 from dotenv import load_dotenv
-import yaml
 import boto3
 import json
 import time
@@ -14,11 +13,15 @@ bedrock_client = boto3.client(
     service_name="bedrock-runtime",
     region_name=os.getenv('region_name'),
     aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
-    aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY")
+    aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
+    aws_session_token=os.getenv("AWS_SESSION_TOKEN") # Comment this line if you are not using temporary session token
 )
 
+# Define Bedrock Model
+MODEL_ID = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+
 # Executing the SQL database chain with the users question
-def athena_answer(question):
+def get_athena_query(question):
     """
     This function collects all necessary information to generate the SQL Query 
     a natural language question in and returning a generated SQL query.
@@ -141,7 +144,7 @@ def athena_answer(question):
     json_prompt = json.dumps(prompt)    
 
     # invoking Claude 3.5, passing in our prompt
-    response = bedrock_client.invoke_model(body=json_prompt, modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+    response = bedrock_client.invoke_model(body=json_prompt, modelId=MODEL_ID,
                                     accept="application/json", contentType="application/json")
     # getting the response from Claude3 and parsing it to return to the end user
     response_body = json.loads(response.get('body').read())
@@ -208,7 +211,7 @@ def get_athena_answer(question, query):
     json_prompt = json.dumps(prompt)    
 
     # invoking Claude3, passing in our prompt
-    response = bedrock_client.invoke_model(body=json_prompt, modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+    response = bedrock_client.invoke_model(body=json_prompt, modelId=MODEL_ID,
                                     accept="application/json", contentType="application/json")
     # getting the response from Claude3.5 and parsing it to return to the end user
     response_body = json.loads(response.get('body').read())

--- a/genai-quickstart-pocs-python/amazon-bedrock-amazon-athena-poc/app.py
+++ b/genai-quickstart-pocs-python/amazon-bedrock-amazon-athena-poc/app.py
@@ -1,5 +1,5 @@
 import streamlit as st
-from amazon_athena_bedrock_query import athena_answer
+from amazon_athena_bedrock_query import get_athena_query
 from amazon_athena_bedrock_query import get_athena_answer
 
 # title of the streamlit app
@@ -29,7 +29,7 @@ if question := st.chat_input("Ask about your stored data that can be accessed by
         # putting a spinning icon to show that the query is in progress
         with st.status("Determining the best possible answer!", expanded=True) as status:
             # passing the question into the athena_answer function, which later invokes the llm
-            query = athena_answer(question)
+            query = get_athena_query(question)
             answer = get_athena_answer(question, query)
             # writing the answer to the front end
             message_placeholder.markdown(f""" Answer:

--- a/genai-quickstart-pocs-python/amazon-bedrock-amazon-athena-poc/app.py
+++ b/genai-quickstart-pocs-python/amazon-bedrock-amazon-athena-poc/app.py
@@ -1,5 +1,6 @@
 import streamlit as st
 from amazon_athena_bedrock_query import athena_answer
+from amazon_athena_bedrock_query import get_athena_answer
 
 # title of the streamlit app
 st.title(f""":rainbow[Natural Language Query Against Amazon Athena]""")
@@ -28,15 +29,16 @@ if question := st.chat_input("Ask about your stored data that can be accessed by
         # putting a spinning icon to show that the query is in progress
         with st.status("Determining the best possible answer!", expanded=True) as status:
             # passing the question into the athena_answer function, which later invokes the llm
-            answer = athena_answer(question)
+            query = athena_answer(question)
+            answer = get_athena_answer(question, query)
             # writing the answer to the front end
             message_placeholder.markdown(f""" Answer:
-                            {answer[1]}
+                            {answer}
                             """)
             # writing the SQL query in code front end style on the sidebar
             with st.sidebar:
                 st.title(f""":green[The SQL command to get this answer was:]""")
-                st.code(answer[0], language="sql")
+                st.code(query, language="sql")
             # showing a completion message to the front end
             status.update(label="Question Answered...", state="complete", expanded=False)
     # appending the results to the session state

--- a/genai-quickstart-pocs-python/amazon-bedrock-amazon-athena-poc/requirements.txt
+++ b/genai-quickstart-pocs-python/amazon-bedrock-amazon-athena-poc/requirements.txt
@@ -13,8 +13,6 @@ botocore==1.34.69
 cachetools==5.3.1
 certifi==2023.7.22
 charset-normalizer==3.3.0
-chroma-hnswlib==0.7.3
-chromadb==0.4.14
 click==8.1.7
 coloredlogs==15.0.1
 dataclasses-json==0.6.1
@@ -29,7 +27,6 @@ GitPython==3.1.41
 grpcio==1.59.0
 h11==0.14.0
 httptools==0.6.0
-huggingface-hub==0.21.4
 humanfriendly==10.0
 idna==3.4
 importlib-metadata==6.8.0
@@ -41,10 +38,6 @@ jsonpatch==1.33
 jsonpointer==2.4
 jsonschema==4.19.1
 jsonschema-specifications==2023.7.1
-langchain==0.1.13
-langchain-community==0.0.31
-langchain-experimental==0.0.55
-langsmith==0.1.17
 markdown-it-py==3.0.0
 MarkupSafe==2.1.3
 marshmallow==3.20.1
@@ -91,9 +84,8 @@ setuptools==68.2.0
 six==1.16.0
 smmap==5.0.1
 sniffio==1.3.0
-SQLAlchemy==2.0.22
 starlette==0.35.0
-streamlit==1.30.0
+streamlit==1.38.0
 sympy==1.12
 tenacity==8.2.3
 threadpoolctl==3.2.0


### PR DESCRIPTION
*Description of changes:*
Hi and thanks for the set of PoC codes.
Based on some experimentations with customers, I would like to propose a simplified version of Amazon-Athena-Poc code. The updated code has been validated by these customers in their own contexts and with their own data.
The key benefits are:
- **Improved readability and learning**: The code explicitly demonstrates how SQL generation is done, executed, and transformed into natural language. This makes it easier to understand and learn from.
- Langchain SQL hides most of the complexity and is prone to several errors and not easy to debug
- **Easier sample entry updates**: Instead of using Langchain SQL samples file, we provide table descriptions and 3 sample entries for a few shot learning. This makes it easier to update than going over a long file.
- **Simplified Athena query execution** : Athena query is executed using Boto3 and not Direct API request (with Athena URI) which simplify the code.
- Bedrock Model update from Amazon Titan to Claude Anthropic.
- **Temporary token usage** : Added support for temporary tokens usage as most customers uses Roles token instead of IAM user token.  And for Athena direct API query, temporary session token was not working (compared to Boto3 client)
- I tested against all the queries in the samples files. All generated queries are correct. I updated the answers (which is probably due to some changes in the original MoMa file, that should be updated as well)
  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
