### PR TITLE
Fixed issue with f-string in generate.py that was causing an exception on Microsoft Windows

### DIFF
--- a/genai-quickstart-pocs-python/amazon-bedrock-powerpoint-generator-poc/powerpoint_generator/generate.py
+++ b/genai-quickstart-pocs-python/amazon-bedrock-powerpoint-generator-poc/powerpoint_generator/generate.py
@@ -137,7 +137,7 @@ def generate_powerpoint_sections(
     response: LLMResponseSections = chain.invoke(input_arguments)
     if write_callback:
         write_callback(
-            f"Presentation sections are {",".join([section.title for section in response.section_slides])}"
+            f"Presentation sections are {','.join([section.title for section in response.section_slides])}"
         )
     return response.section_slides
 

--- a/genai-quickstart-pocs-python/amazon-bedrock-powerpoint-generator-poc/powerpoint_generator/powerpoint.py
+++ b/genai-quickstart-pocs-python/amazon-bedrock-powerpoint-generator-poc/powerpoint_generator/powerpoint.py
@@ -51,7 +51,7 @@ def generate_powerpoint_file(topic: str, presentation_content: list[CompleteSect
 
     conclusion_slide = preso.slides.add_slide(section_header_slide_layout)
     conclusion_slide.shapes.placeholders[0].text = "Thank You!"
-    file_path = os.path.join(os.path.dirname(__file__), f"../temp/{uuid4()}.pptx")
+    file_path = os.path.join(os.path.dirname(__file__), f"{uuid4()}.pptx")
     preso.save(file_path)
     logger.info("PowerPoint file generated successfully!")
     if write_callback:


### PR DESCRIPTION
*Issue #, if available:* N/A

Prior to this change, the `generate.py` file was causing the following exception:

```
2024-11-22 21:36:07.443 Uncaught app exception
Traceback (most recent call last):
  File "C:\coderepo\genai-quickstart-pocs\genai-quickstart-pocs-python\amazon-bedrock-powerpoint-generator-poc\.venv\Lib\site-packages\streamlit\runtime\scriptrunner\exec_code.py", line 88, in exec_func_with_error_handling
    result = func()
             ^^^^^^
  File "C:\coderepo\genai-quickstart-pocs\genai-quickstart-pocs-python\amazon-bedrock-powerpoint-generator-poc\.venv\Lib\site-packages\streamlit\runtime\scriptrunner\script_runner.py", line 579, in code_to_exec
    exec(code, module.__dict__)
  File "C:\coderepo\genai-quickstart-pocs\genai-quickstart-pocs-python\amazon-bedrock-powerpoint-generator-poc\app.py", line 2, in <module>
    from powerpoint_generator import generate_powerpoint
  File "C:\coderepo\genai-quickstart-pocs\genai-quickstart-pocs-python\amazon-bedrock-powerpoint-generator-poc\powerpoint_generator\__init__.py", line 14, in <module>
    from .generate import (
  File "C:\coderepo\genai-quickstart-pocs\genai-quickstart-pocs-python\amazon-bedrock-powerpoint-generator-poc\powerpoint_generator\generate.py", line 140
    f"Presentation sections are {",".join([section.title for section in response.section_slides])}"
                                  ^
SyntaxError: f-string: expecting '}'
```

When running in Powershell, with

```
PS C:\Users\troyd> Get-ComputerInfo | Select-Object WindowsVersion, WindowsBuildLabEx, WindowsEditionId
WindowsVersion WindowsBuildLabEx                       WindowsEditionId
-------------- -----------------                       ----------------
2009           22621.1.amd64fre.ni_release.220506-1250 Professional
```

```
PS C:\Users\troyd> python --version
Python 3.11.7
```

*Description of changes:*

* Replaced the `"` with `'` in the Python f-string

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
