### PR TITLE
Fixed f-string issue in generate, along with file saving abilities in powerpoint.py

### DIFF
--- a/genai-quickstart-pocs-python/amazon-bedrock-powerpoint-generator-poc/powerpoint_generator/generate.py
+++ b/genai-quickstart-pocs-python/amazon-bedrock-powerpoint-generator-poc/powerpoint_generator/generate.py
@@ -137,7 +137,7 @@ def generate_powerpoint_sections(
     response: LLMResponseSections = chain.invoke(input_arguments)
     if write_callback:
         write_callback(
-            f"Presentation sections are {",".join([section.title for section in response.section_slides])}"
+            f"Presentation sections are {','.join([section.title for section in response.section_slides])}"
         )
     return response.section_slides
 

--- a/genai-quickstart-pocs-python/amazon-bedrock-powerpoint-generator-poc/powerpoint_generator/powerpoint.py
+++ b/genai-quickstart-pocs-python/amazon-bedrock-powerpoint-generator-poc/powerpoint_generator/powerpoint.py
@@ -51,7 +51,7 @@ def generate_powerpoint_file(topic: str, presentation_content: list[CompleteSect
 
     conclusion_slide = preso.slides.add_slide(section_header_slide_layout)
     conclusion_slide.shapes.placeholders[0].text = "Thank You!"
-    file_path = os.path.join(os.path.dirname(__file__), f"../temp/{uuid4()}.pptx")
+    file_path = os.path.join(os.path.dirname(__file__), f"{uuid4()}.pptx")
     preso.save(file_path)
     logger.info("PowerPoint file generated successfully!")
     if write_callback:


### PR DESCRIPTION
*Issue #, if available:*

- Reference: https://github.com/aws-samples/genai-quickstart-pocs/pull/335 
- Fixed the ability to create a `pptx`/`ppt` file with Streamlit

*Description of changes:*

- Fixed the local path for users consuming this in a Microsoft Windows environment (ie. Powershell)
- The `reset()` function no longer clears or modifies the `background_files` key in `st.session_state` to comply with Streamlit's policies.
- The `process_uploads()` function now uses `st.session_state.get("background_files", [])` to ensure it handles cases where no files are uploaded or the key is not present.
 - The `file_uploader` widget state is maintained solely by Streamlit without being programmatically reset.
- Updated the state management to align with Streamlit's restrictions on modifying widget values programmatically, preventing `StreamlitValueAssignmentNotAllowedError`.
- The reset behavior focuses on clearing text fields and toggles while allowing users to manage uploaded files naturally without forced resets.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
